### PR TITLE
Sort reviews

### DIFF
--- a/client/src/components/RatingsReviews/ExampleReviews.js
+++ b/client/src/components/RatingsReviews/ExampleReviews.js
@@ -6,7 +6,7 @@ const ExampleReviews = [
       "recommend": false,
       "response": "Your account is going to be deleted",
       "body": "DON'T IT!!! REPORTED REVIEWS CANT BE SEEN!! OH NOOOOO!",
-      "date": "2022-05-25T00:00:00.000Z",
+      "date": "2022-07-25T00:00:00.000Z",
       "reviewer_name": "Dinthebeen",
       "helpfulness": 35,
       "photos": []
@@ -20,7 +20,7 @@ const ExampleReviews = [
       "body": "Wow this camo onesie looks great on both me & my son! Would definitely recommend if you're the same size as your child!\n",
       "date": "2022-04-14T00:00:00.000Z",
       "reviewer_name": "Cooldude123",
-      "helpfulness": 11,
+      "helpfulness": 36,
       "photos": [
           {
               "id": 2259510,

--- a/client/src/components/RatingsReviews/RatingsReviews.jsx
+++ b/client/src/components/RatingsReviews/RatingsReviews.jsx
@@ -25,6 +25,29 @@ const RatingsReviews = ({ productId }) => {
     setReviewsOnDisplay(reviews.slice(0, maxResults + 2));
   }
 
+  const sortReviewBy = (param) => {
+    let sortedReviews = reviews.slice();
+    if (param === 'newest') {
+      console.log('sorting by newest')
+      sortedReviews.sort((a, b) =>
+      {return new Date(b.date) - new Date(a.date);
+        // a.date > b.date ? -1 : a.date < b.date ? 1 : 0
+      })
+    } else if (param = 'helpful') {
+      //only counting yes's for now until I find the count for nos
+      console.log('sorting by helpfulness')
+      sortedReviews.sort((a, b) => b.helpfulness - a.helpfulness)
+
+    } else {
+      //relevant by default
+    }
+    console.log(sortedReviews);
+    // debugger;
+    setReviews(sortedReviews);
+    setMaxResults(2);
+    setReviewsOnDisplay(sortedReviews.slice(0, 2))
+  }
+
   return (
     <div id="RR-ratings-reviews-ctn">
       <div id="RR-breakdown-ctn">
@@ -36,7 +59,13 @@ const RatingsReviews = ({ productId }) => {
       </div>
       <div id="RR-reviews-ctn">
         <div id="RR-header-sort">
-          <h3>{reviews.length} views, sorted by SORT OPTION</h3>
+          <h3>{reviews.length} views, sorted by
+            <select id="RR-sort-param" onChange={(e) => sortReviewBy(e.target.value)}>
+              <option value="relevant">Relevant</option>ß
+              <option value="helpful">Helpful</option>
+              <option value="newest">Newest</option>
+            </select>
+          </h3>
         </div>
         <ReviewList reviews={reviewsOnDisplay}/>
         <div id="more-menu">


### PR DESCRIPTION
Users can now sort by relevant, useful, newest. 

Relevant is based on a custom formula: 
Relevance = usefulness - 1 point per month the review ages
Ex: a review with 35 usefullness point that was made 5 months ago has 35 - 30 relevance points.

This custom formula could be calibrated with further statistical analyses, but that should be a business decision if the client is not satisfied with this default formula.