### PR TITLE
Fixed bug with stars

### DIFF
--- a/client/src/components/RatingsReviews/ExampleReviews.js
+++ b/client/src/components/RatingsReviews/ExampleReviews.js
@@ -1,7 +1,7 @@
 const someReviews = [
   {
       "review_id": 1274546,
-      "rating": 2.8,
+      "rating": 2.9,
       "summary": "PLEASE DON'T REPORT ME",
       "recommend": false,
       "response": "Your account is going to be deleted",
@@ -13,7 +13,7 @@ const someReviews = [
   },
   {
       "review_id": 1176362,
-      "rating": 0.05,
+      "rating": 1.01,
       "summary": "Looks radical dude!",
       "recommend": true,
       "response": null,

--- a/client/src/components/helpers/Stars.jsx
+++ b/client/src/components/helpers/Stars.jsx
@@ -12,9 +12,11 @@ const Stars = ({ rating }) => {
   let remainder = rating % 1;
   let partialCount = (Math.round(remainder * 4) / 4).toFixed(2);
   let partialStars = {
+    '0.00' : noStar,
     '0.25' : quarterStar,
     '0.50' : halfStar,
-    '0.75' : threeQuartersStar
+    '0.75' : threeQuartersStar,
+    '1.00' : fullStar
   }
 
   for (let i = 0; i < fullStarCount; i++) {


### PR DESCRIPTION
 a decimal value now correctly renders no star or a full star

BEFORE a 3.9 would yield 3 full stars, undefined image, and blank star, 
now it yields 4 full stars and 1 blank star